### PR TITLE
Add custom signer support (v1.2.0)

### DIFF
--- a/configure_credparser.py
+++ b/configure_credparser.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python3
 '''
-make_credentials.py
+configure_credparser.py
 
-Command-line utility to generate encoded credential strings using credparser.
+Command-line utility to configure credparser settings.
 '''
 
 from credparser import configure_credparser
 
 
 if __name__ == "__main__":
-   configure_credparser()
+    configure_credparser()

--- a/credparser/__init__.py
+++ b/credparser/__init__.py
@@ -1,7 +1,24 @@
 '''
 credparser / __init__
 '''
-__version__ = '1.1.0'
+from importlib.metadata import version, PackageNotFoundError
+try:
+    __version__ = version('credparser')
+except PackageNotFoundError:
+    __version__ = 'embedded'
+
+import logging
+import os
+
+# Configure debug logging if CREDPARSER_DEBUG is set
+if os.environ.get('CREDPARSER_DEBUG'):
+    _handler = logging.StreamHandler()
+    _handler.setFormatter(logging.Formatter(
+        '%(name)s.%(funcName)s() [%(levelname)s] %(message)s'
+    ))
+    _pkg_logger = logging.getLogger(__name__)
+    _pkg_logger.setLevel(logging.DEBUG)
+    _pkg_logger.addHandler(_handler)
 
 # Load and trigger configuration processing
 from .config import config

--- a/credparser/__main__.py
+++ b/credparser/__main__.py
@@ -21,7 +21,7 @@ This differs from console_scripts entry points defined in pyproject.toml:
 Relationship to pyproject.toml:
     [project.scripts]
     credparser-make = "credparser.guide:make_credentials"
-    credparser-config = "credparser.guide:configure_credparser"
+    credparser-config = "credparser.guide:configure_credparser_cli"
 
 These entry points are separate from __main__.py. Both approaches serve
 different use cases:

--- a/credparser/guide.py
+++ b/credparser/guide.py
@@ -161,9 +161,9 @@ def _configure_interactive(
     Returns:
         Tuple of (salt_len, max_hash_rounds, min_hash_rounds)
     '''
-    print(f'Salt Length')
+    print('Salt Length')
     print(f'{"=" * 40}')
-    print(f'Salt works as the public key for your credparser credentials.')
+    print('Salt works as the public key for your credparser credentials.')
     print(f'Salt length must be {LIMIT_MIN_SALT_LEN} or larger.')
     print()
 
@@ -180,9 +180,9 @@ def _configure_interactive(
     print()
     print(f'Hashing Rounds')
     print(f'{"=" * 40}')
-    print(f'Hashing rounds are deterministically set using the salt as a seed')
-    print(f'and provide the core encryption/key generation functionality.')
-    print(f'Hash round maximums should optimally be >3x the minimum at least.')
+    print('Hashing rounds are deterministically set using the salt as a seed')
+    print('and provide the core encryption/key generation functionality.')
+    print('Hash round maximums should optimally be >3x the minimum at least.')
     print()
 
     # Min hash rounds
@@ -224,7 +224,8 @@ def configure_credparser(
     Writes configuration to the module's .config file.
 
     Args:
-        salt_len: Salt length (int). If provided with hash rounds, uses non-interactive mode.
+        salt_len: Salt length (int). If provided with hash rounds, uses
+            non-interactive mode.
         min_hash_rounds: Minimum hash rounds (int)
         max_hash_rounds: Maximum hash rounds (int)
         test: If True, validate and display current configuration without modifying
@@ -262,7 +263,9 @@ def configure_credparser(
 
     try:
         # Determine if interactive or non-interactive mode
-        if salt_len is not None and min_hash_rounds is not None and max_hash_rounds is not None:
+        if (salt_len is not None
+                and min_hash_rounds is not None
+                and max_hash_rounds is not None):
             # Non-interactive mode: use provided parameters
             _logger.debug('Non-interactive mode: using provided parameters')
             new_salt_len = salt_len
@@ -299,7 +302,10 @@ def configure_credparser(
             skip_warning = False
         else:
             # Partial parameters provided - error
-            print("Error: Either provide all three parameters (salt_len, min_hash_rounds, max_hash_rounds)")
+            print(
+                "Error: Either provide all three parameters"
+                " (salt_len, min_hash_rounds, max_hash_rounds)"
+            )
             print("       or provide none for interactive mode")
             sys.exit(1)
 
@@ -451,7 +457,9 @@ def configure_credparser_cli() -> None:
             configure_credparser(help=True)
         elif args.test:
             configure_credparser(test=True)
-        elif args.salt_len is not None or args.min_hash is not None or args.max_hash is not None:
+        elif (args.salt_len is not None
+                or args.min_hash is not None
+                or args.max_hash is not None):
             # Non-interactive mode
             configure_credparser(
                 salt_len=args.salt_len,

--- a/credparser/seed.py
+++ b/credparser/seed.py
@@ -25,7 +25,9 @@ class MasterSeed():
         try:
             self._allow_init = bool(allow_init)
             self.seed_path = Path(seed_path)
-            _logger.debug(f'MasterSeed init: path={self.seed_path}, allow_init={allow_init}')
+            _logger.debug(
+                f'MasterSeed init: path={self.seed_path}, allow_init={allow_init}'
+            )
 
             if self.seed_path.exists():
                 _logger.debug(f'Seed file exists: {self.seed_path}')
@@ -47,9 +49,9 @@ class MasterSeed():
             self._create_seed_file()
 
         except InitFailure:
-                raise
+            raise
         except Exception as e:
-                raise InitFailure(f"Unexpected error during seed initialization: {e}")
+            raise InitFailure(f"Unexpected error during seed initialization: {e}")
 
     def __str__(self):
         return f'MasterSeed(seed_path={str(self.seed_path)})'
@@ -75,7 +77,7 @@ class MasterSeed():
             raise InitFailure(f"Failed to read seed file {self.seed_path}: {e}")
 
 
-    def _create_credparser_dir(self,) -> None:
+    def _create_credparser_dir(self) -> None:
         ''' Create the credparse seed storage directory '''
         # Get the parent (dir) for the master_seed file as a Path()
         seed_dir = Path(self.seed_path).parent
@@ -85,7 +87,9 @@ class MasterSeed():
             # Verify permissions in case directory already existed
             current_mode = stat.S_IMODE(os.stat(seed_dir).st_mode)
             if current_mode != 0o700:
-                _logger.debug(f'Adjusting directory permissions from {oct(current_mode)} to 0o700')
+                _logger.debug(
+                    f'Adjusting directory permissions from {oct(current_mode)} to 0o700'
+                )
                 os.chmod(seed_dir, 0o700)
             _logger.debug(f'Seed directory ready: {seed_dir}')
         except (OSError, PermissionError) as e:
@@ -118,7 +122,9 @@ class MasterSeed():
             # Verify/set file permissions
             current_mode = stat.S_IMODE(os.stat(seed_path).st_mode)
             if current_mode != 0o600:
-                _logger.debug(f'Adjusting file permissions from {oct(current_mode)} to 0o600')
+                _logger.debug(
+                    f'Adjusting file permissions from {oct(current_mode)} to 0o600'
+                )
                 os.chmod(seed_path, 0o600)
             _logger.debug(f'Seed file created successfully: {seed_path}')
 

--- a/make_credentials.py
+++ b/make_credentials.py
@@ -9,4 +9,4 @@ from credparser import make_credentials
 
 
 if __name__ == "__main__":
-   make_credentials()
+    make_credentials()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,11 +4,11 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "credparser"
-version = "1.1.0"
+version = "1.2.0"
 description = "Light-weight credential embedding solution for scripting environments"
 readme = "README.md"
 license = {text = "MIT"}
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
@@ -16,12 +16,12 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Security",
     "Topic :: Utilities",
 ]


### PR DESCRIPTION
## Summary

- Adds a `signer` parameter to `CredParser` (and all internal
  encode/decode functions) to override the default OS-username-based
  signing. Intended for cross-platform and multi-user deployments
  where credentials must be decoded by a different user or on a
  different machine than where they were encoded.
- Bumps version to 1.2.0 and switches to `importlib.metadata` for
  version resolution, with an `"embedded"` fallback for projects that
  hardfork/embed the library without the package metadata.
- Standardizes public API parameter ordering across all signatures
  (`username`, `password`, `credentials`, `signer`, `seed_path`).
- Formatting and correctness pass across all source files.